### PR TITLE
go/types: Checker.identical0() fix

### DIFF
--- a/src/go/types/predicates.go
+++ b/src/go/types/predicates.go
@@ -291,7 +291,7 @@ func (check *Checker) identical0(x, y Type, cmpTags bool, p *ifacePair) bool {
 		// Two named types are identical if their type names originate
 		// in the same type declaration.
 		if y, ok := y.(*Named); ok {
-			return x.obj == y.obj
+			return x.obj.String() == y.obj.String()
 		}
 
 	case nil:


### PR DESCRIPTION
Checker.identical0() should compare TypeNames by value.

Fixes #35265
